### PR TITLE
Interrupt safety and remove sysTick from global

### DIFF
--- a/Wiegand.cpp
+++ b/Wiegand.cpp
@@ -1,12 +1,11 @@
 #include "Wiegand.h"
 
-unsigned long WIEGAND::_cardTempHigh=0;
-unsigned long WIEGAND::_cardTemp=0;
-unsigned long WIEGAND::_lastWiegand=0;
-unsigned long WIEGAND::_sysTick=0;
+volatile unsigned long WIEGAND::_cardTempHigh=0;
+volatile unsigned long WIEGAND::_cardTemp=0;
+volatile unsigned long WIEGAND::_lastWiegand=0;
 unsigned long WIEGAND::_code=0;
-int 		  WIEGAND::_bitCount=0;	
-int			  WIEGAND::_wiegandType=0;
+volatile int WIEGAND::_bitCount=0;	
+int WIEGAND::_wiegandType=0;
 
 WIEGAND::WIEGAND()
 {
@@ -24,7 +23,11 @@ int WIEGAND::getWiegandType()
 
 bool WIEGAND::available()
 {
-	return DoWiegandConversion();
+	bool ret;
+    noInterrupts();
+	ret=DoWiegandConversion();
+	interrupts();
+	return ret;
 }
 
 void WIEGAND::begin()
@@ -35,7 +38,6 @@ void WIEGAND::begin()
 	_code = 0;
 	_wiegandType = 0;
 	_bitCount = 0;  
-	_sysTick=millis();
 	pinMode(D0Pin, INPUT);					// Set D0 pin as input
 	pinMode(D1Pin, INPUT);					// Set D1 pin as input
 	attachInterrupt(0, ReadD0, FALLING);	// Hardware interrupt - high to low pulse
@@ -55,7 +57,7 @@ void WIEGAND::ReadD0 ()
 	{
 		_cardTemp <<= 1;		// D0 represent binary 0, so just left shift card data
 	}
-	_lastWiegand = _sysTick;	// Keep track of last wiegand bit received
+	_lastWiegand = millis();	// Keep track of last wiegand bit received
 }
 
 void WIEGAND::ReadD1()
@@ -73,10 +75,10 @@ void WIEGAND::ReadD1()
 		_cardTemp |= 1;			// D1 represent binary 1, so OR card data with 1 then
 		_cardTemp <<= 1;		// left shift card data
 	}
-	_lastWiegand = _sysTick;	// Keep track of last wiegand bit received
+	_lastWiegand = millis();	// Keep track of last wiegand bit received
 }
 
-unsigned long WIEGAND::GetCardId (unsigned long *codehigh, unsigned long *codelow, char bitlength)
+unsigned long WIEGAND::GetCardId (volatile unsigned long *codehigh, volatile unsigned long *codelow, char bitlength)
 {
 	unsigned long cardID=0;
 
@@ -96,9 +98,9 @@ unsigned long WIEGAND::GetCardId (unsigned long *codehigh, unsigned long *codelo
 bool WIEGAND::DoWiegandConversion ()
 {
 	unsigned long cardID;
+	unsigned long sysTick = millis();
 	
-	_sysTick=millis();
-	if ((_sysTick - _lastWiegand) > 25)								// if no more signal coming through after 25ms
+	if ((sysTick - _lastWiegand) > 25)								// if no more signal coming through after 25ms
 	{
 		if ((_bitCount==26) || (_bitCount==34) || (_bitCount==8)) 	// bitCount for keypress=8, Wiegand 26=26, Wiegand 34=34
 		{
@@ -148,7 +150,7 @@ bool WIEGAND::DoWiegandConversion ()
 		else
 		{
 			// well time over 25 ms and bitCount !=8 , !=26, !=34 , must be noise or nothing then.
-			_lastWiegand=_sysTick;
+			_lastWiegand=sysTick;
 			_bitCount=0;			
 			_cardTemp=0;
 			_cardTempHigh=0;

--- a/Wiegand.h
+++ b/Wiegand.h
@@ -24,13 +24,12 @@ private:
 	static void ReadD0();
 	static void ReadD1();
 	static bool DoWiegandConversion ();
-	static unsigned long GetCardId (unsigned long *codehigh, unsigned long *codelow, char bitlength);
+	static unsigned long GetCardId (volatile unsigned long *codehigh, volatile unsigned long *codelow, char bitlength);
 	
-	static unsigned long 	_cardTempHigh;
-	static unsigned long 	_cardTemp;
-	static unsigned long 	_lastWiegand;
-	static unsigned long 	_sysTick;
-	static int				_bitCount;	
+	static volatile unsigned long 	_cardTempHigh;
+	static volatile unsigned long 	_cardTemp;
+	static volatile unsigned long 	_lastWiegand;
+	static volatile int				_bitCount;	
 	static int				_wiegandType;
 	static unsigned long	_code;
 };


### PR DESCRIPTION
This commit makes three main changes:
1.) declare all variables that are shared between ISR and main code
(especially doWiegandConversion() ) volatile. I hope this is correct
that way also in header file …
2.) remove sysTick from needed to be a global class variable because it
is only set by DoWiegandConversion and only used by the ISRs. hen there
is work in main loop that prevents „available“ from being called often
then the sysTick value could be rather old and then the 25ms check in
DoWiegandConversion may return wrong things
3.) disable interrupts (ok, using Arduino specific functions, but
available in this case) before calling DoWiegandConversion in method
available() to make sure the variables are not modified by one of the
ISRs right in the middle of checking or using.

See also issue#3 discussions