### PR TITLE
make Pins and Interrupts optionally configurable

### DIFF
--- a/Wiegand.cpp
+++ b/Wiegand.cpp
@@ -29,6 +29,11 @@ bool WIEGAND::available()
 
 void WIEGAND::begin()
 {
+  begin(2,0,3,1);
+}
+
+void WIEGAND::begin(int pinD0, int pinIntD0, int pinD1, int pinIntD1)
+{
 	_lastWiegand = 0;
 	_cardTempHigh = 0;
 	_cardTemp = 0;
@@ -36,10 +41,10 @@ void WIEGAND::begin()
 	_wiegandType = 0;
 	_bitCount = 0;  
 	_sysTick=millis();
-	pinMode(D0Pin, INPUT);					// Set D0 pin as input
-	pinMode(D1Pin, INPUT);					// Set D1 pin as input
-	attachInterrupt(0, ReadD0, FALLING);	// Hardware interrupt - high to low pulse
-	attachInterrupt(1, ReadD1, FALLING);	// Hardware interrupt - high to low pulse
+	pinMode(pinD0, INPUT);					// Set D0 pin as input
+	pinMode(pinD1, INPUT);					// Set D1 pin as input
+	attachInterrupt(pinIntD0, ReadD0, FALLING);	// Hardware interrupt - high to low pulse
+	attachInterrupt(pinIntD1, ReadD1, FALLING);	// Hardware interrupt - high to low pulse
 }
 
 void WIEGAND::ReadD0 ()

--- a/Wiegand.h
+++ b/Wiegand.h
@@ -7,15 +7,12 @@
 #include "WProgram.h"
 #endif
 
-#define D0Pin 2			// Arduino Pin 2 Hardware interrupt
-#define D1Pin 3			// Arduino Pin 3 Hardware interrupt
-
-
 class WIEGAND {
 
 public:
 	WIEGAND();
 	void begin();
+	void begin(int pinD0, int pinIntD0, int pinD1, int pinIntD1);
 	bool available();
 	unsigned long getCode();
 	int getWiegandType();


### PR DESCRIPTION
Add a second begin()-method to have the Pins for D0 and D1 and the
Interrupts to use configurable. The default begin()-method without
parameters still use default pins 2 and 3 and int 0 and 1.
maybe with this small change the library can be used for all pins with
external interruption other boards then UNO more flexible.

Also see discussion in issue #1.