### PR TITLE
Support 4-bit Wiegand codes

### DIFF
--- a/Wiegand.cpp
+++ b/Wiegand.cpp
@@ -100,6 +100,19 @@ unsigned long WIEGAND::GetCardId (volatile unsigned long *codehigh, volatile uns
 	return cardID;
 }
 
+char translateEnterEscapeKeyPress(char originalKeyPress) {
+    switch(originalKeyPress) {
+        case 0x0b:        // 11 or * key
+            return 0x0d;  // 13 or ASCII ENTER
+
+        case 0x0a:        // 10 or # key
+            return 0x1b;  // 27 or ASCII ESCAPE
+
+        default:
+            return originalKeyPress;
+    }
+}
+
 bool WIEGAND::DoWiegandConversion ()
 {
 	unsigned long cardID;
@@ -107,7 +120,7 @@ bool WIEGAND::DoWiegandConversion ()
 	
 	if ((sysTick - _lastWiegand) > 25)								// if no more signal coming through after 25ms
 	{
-		if ((_bitCount==26) || (_bitCount==34) || (_bitCount==8)) 	// bitCount for keypress=8, Wiegand 26=26, Wiegand 34=34
+		if ((_bitCount==26) || (_bitCount==34) || (_bitCount==8) || (_bitCount==4)) 	// bitCount for keypress=4 or 8, Wiegand 26=26, Wiegand 34=34
 		{
 			_cardTemp >>= 1;			// shift right 1 bit to get back the real value - interrupt done 1 left shift in advance
 			if (_bitCount>32)			// bit count more than 32 bits, shift high bits right to make adjustment
@@ -123,7 +136,7 @@ bool WIEGAND::DoWiegandConversion ()
 				_code=cardID;
 				return true;				
 			}
-			else if (_bitCount==8)		// keypress wiegand
+			else if (_bitCount==8)		// keypress wiegand with integrity
 			{
 				// 8-bit Wiegand keyboard data, high nibble is the "NOT" of low nibble
 				// eg if key 1 pressed, data=E1 in binary 11100001 , high nibble=1110 , low nibble = 0001 
@@ -135,22 +148,25 @@ bool WIEGAND::DoWiegandConversion ()
 				_cardTempHigh=0;
 				
 				if (lowNibble == (~highNibble & 0x0f))		// check if low nibble matches the "NOT" of high nibble.
-				{
-					if (lowNibble==0x0b)					// ENT pressed
-					{
-						_code=0x0d;							
-					}
-					else if (lowNibble==0x0a)				// ESC pressed
-					{
-						_code=0x1b;							
-					}
-					else
-					{
-						_code=(int)lowNibble;				// 0 - 9 keys
-					}
+                {
+                    _code = (int)translateEnterEscapeKeyPress(lowNibble);
 					return true;
 				}
+
+                // TODO: Handle validation failure case!
 			}
+            else if (4 == _bitCount) {
+                // 4-bit Wiegand codes have no data integrity check so we just
+                // read the LOW nibble.
+                _code = (int)translateEnterEscapeKeyPress(_cardTemp & 0x0000000F);
+
+                _wiegandType = _bitCount;
+                _bitCount = 0;
+                _cardTemp = 0;
+                _cardTempHigh = 0;
+
+                return true;
+            }
 		}
 		else
 		{


### PR DESCRIPTION
These are the same as 8-bit codes (the lower nibble contains the keypress) but without the integrity check.

Note that I've factored out the translation of `*` -> `ESC` and `#` to `ENTER`