### PR TITLE
Use digitalPinToInterrupt on newer Arduino software, if present

### DIFF
--- a/Wiegand.cpp
+++ b/Wiegand.cpp
@@ -32,7 +32,12 @@ bool WIEGAND::available()
 
 void WIEGAND::begin()
 {
+#ifdef digitalPinToInterrupt
+  // newer versions of Arduino provide pin to interrupt mapping
+  begin(2,digitalPinToInterrupt(2),3,digitalPinToInterrupt(3));
+#else
   begin(2,0,3,1);
+#endif
 }
 
 void WIEGAND::begin(int pinD0, int pinIntD0, int pinD1, int pinIntD1)


### PR DESCRIPTION
This small change will make your library compatible with Teensy, Arduino Due and other newer board which do not have pin-to-interrupt mapping identical to Arduino Uno.

With older versions of Arduino which do not define digitalPinToInterrupt(), it automatically falls back to your original code.

At least one customer has verified this works with the hardware.  Conversation is here:
https://forum.pjrc.com/threads/31989-Wiegand-Library-and-Example-Sketch-Work-on-Uno-but-not-Teensy-3-1-HALP!?p=90578&viewfull=1#post90578