### PR TITLE
Update WiegandTest.ino added proper pin definitions for Leonardo 

### DIFF
--- a/examples/WiegandTest/WiegandTest.ino
+++ b/examples/WiegandTest/WiegandTest.ino
@@ -4,7 +4,7 @@ WIEGAND wg;
 
 void setup() {
 	Serial.begin(9600);  
-	wg.begin();
+	wg.begin(2, 3);
 }
 
 void loop() {


### PR DESCRIPTION
new IDE compatibility, and pin definitions in init, , now works on Leonardo, and also on ESP