### PR TITLE
Add support for ESP32's variation of the run-from-ram flag.

### DIFF
--- a/Wiegand.cpp
+++ b/Wiegand.cpp
@@ -2,6 +2,8 @@
 
 #if defined(ESP8266)
     #define INTERRUPT_ATTR ICACHE_RAM_ATTR
+#elif defined(ESP32)
+	#define INTERRUPT_ATTR IRAM_ATTR
 #else
     #define INTERRUPT_ATTR
 #endif


### PR DESCRIPTION
I ran this on an ESP32 and needed a slightly different flag from the ESP8266. Same concept, however.