### PR TITLE
Added library.properties for Eclipse CDT drop-in compatibility.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Wiegand Protocol Library for Arduino
+version=git
+author=JP Liew
+maintainer=https://github.com/monkeyboard
+sentence=Wiegand 26 and Wiegand 34 Protocol Library for Arduino
+paragraph=The Wiegand interface is a de facto standard commonly used to connect a card reader or keypad to an electronic entry system. Wiegand interface has the ability to transmit signal over long distance with a simple 3 wires connection. This library uses interrupt pins from Arduino to read the pulses from Wiegand interface and return the code and type of the Wiegand.
+category=Communication
+url=https://github.com/monkeyboard/Wiegand-Protocol-Library-for-Arduino.git
+architectures=*


### PR DESCRIPTION
Adding this file will allow a checkout in ~/.arduinocdt/libraries/ to be visible to Eclipse CDT.  Details have been taken from monkeyboard GitHub profile.

https://stackoverflow.com/questions/29051576/how-do-i-add-arduino-libraries-to-eclipse-project

https://www.eclipse.org/forums/index.php/t/1089603/